### PR TITLE
Issue#13 user auth

### DIFF
--- a/backend/api/admin.py
+++ b/backend/api/admin.py
@@ -8,6 +8,7 @@ from .models.follower import Follower
 from .models.friend import Friend
 from .models.inbox import Inbox
 from django.conf import settings
+from django.contrib.auth.hashers import make_password
 
 # Register your models here.
 admin.site.register(Post)
@@ -28,7 +29,7 @@ admin.site.register(Inbox)
 #       None
 def accept_signup_request(ModelAdmin, request, queryset):
     for req in queryset:
-        a = Author(username=req.username, password=req.password, host = settings.HOST_URL, git_url=req.git_url)
+        a = Author(username=req.username, password=make_password(req.password), host = settings.HOST_URL, git_url=req.git_url)
         a.url = f'{settings.HOST_URL}author/{a.id}'
         a.save()
     queryset.delete()

--- a/backend/api/models/author.py
+++ b/backend/api/models/author.py
@@ -11,7 +11,7 @@ class Author(AbstractUser):
     # User name should be handled because the User model takes first and last name
     id = models.UUIDField(primary_key=True, default=uuid.uuid4)
 
-    token   = models.CharField(max_length=200) # Not Sure what this field is for
+    displayName = models.CharField(blank=True, max_length=150)
     
     # Which host this user was created on
     host    = models.URLField(max_length=500)

--- a/backend/api/models/signupRequest.py
+++ b/backend/api/models/signupRequest.py
@@ -22,6 +22,8 @@ def validate_username_nonexist_in_author(the_username):
     
 # model: store sign up requests for admin to accept or decline
 class Signup_Request(models.Model):
+    
+    displayName = models.CharField(blank=True, max_length=150)
 
     # same fromat requirement as Author
     username    =   models.CharField(primary_key=True, error_messages={'unique': 'The username is already requested by other applier.'}, help_text='Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only.', max_length=150, unique=True,\
@@ -32,3 +34,6 @@ class Signup_Request(models.Model):
 
     # Github page
     git_url     =   models.URLField(default='http://github.com/' ,max_length=500)
+
+    # Which host this user was created on
+    host        =   models.URLField(max_length=500)

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -1,12 +1,13 @@
-from django.urls import path, re_path
+from django.urls import path, re_path, include
 from django.conf.urls import url
 
-from .views import index, simplePostView
+from .views import index, simplePostView, author
 
 
 urlpatterns = [
     path('', index.index, name="index"),
     path(r'author/<str:author_id>/posts/', simplePostView.createNewPost, name="post-post-view"),
     path(r'author/<str:author_id>/posts/<str:post_id>', simplePostView.handleExistPost, name="get-post-view"),
+    path('api-auth/', include('rest_framework.urls')),    
 ]
 

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path, re_path, include
 from django.conf.urls import url
 
-from .views import index, simplePostView, author
+from .views import index, simplePostView
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -2,6 +2,7 @@ from django.urls import path, re_path, include
 from django.conf.urls import url
 
 from .views import index, simplePostView, author
+from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 
 urlpatterns = [
@@ -9,5 +10,7 @@ urlpatterns = [
     path(r'author/<str:author_id>/posts/', simplePostView.createNewPost, name="post-post-view"),
     path(r'author/<str:author_id>/posts/<str:post_id>', simplePostView.handleExistPost, name="get-post-view"),
     path('api-auth/', include('rest_framework.urls')),    
+    path('api/token/', TokenObtainPairView.as_view()),
+    path('api/token/refresh/', TokenRefreshView.as_view()),
 ]
 

--- a/backend/auth_readme.md
+++ b/backend/auth_readme.md
@@ -1,0 +1,60 @@
+Permission guide
+
+Example usage:
+view available only when login using 'IsAuthenticated'
+
+    import:
+            from rest_framework.decorators import permission_classes
+            from rest_framework.permissions import IsAuthenticated
+
+    For function based views:
+        
+        add:
+            @permission_classes([IsAuthenticated])
+            before function
+
+    For class based views:
+
+        add:
+            permission_classes = [IsAuthenticated]
+            inside class
+
+For more permission options and usage: 
+    https://www.django-rest-framework.org/api-guide/permissions/
+
+
+JWT guide
+
+Usage example:
+
+    Get token:
+        curl \
+        -X POST \
+        -H "Content-Type: application/json" \
+        -d '{"username": "<username>", "password": "<password>"}' \
+        http://localhost:8000/api/token/
+
+        ...
+        {
+        "access":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX3BrIjoxLCJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiY29sZF9zdHVmZiI6IuKYgyIsImV4cCI6MTIzNDU2LCJqdGkiOiJmZDJmOWQ1ZTFhN2M0MmU4OTQ5MzVlMzYyYmNhOGJjYSJ9.NHlztMGER7UADHZJlxNG0WSi22a2KaYSfd1S-AuT7lU",
+        "refresh":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX3BrIjoxLCJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImNvbGRfc3R1ZmYiOiLimIMiLCJleHAiOjIzNDU2NywianRpIjoiZGUxMmY0ZTY3MDY4NDI3ODg5ZjE1YWMyNzcwZGEwNTEifQ.aEoAYkSJjoWH1boshQAaTkf8G3yn0kapko6HFRt7Rh4"
+        }
+
+    Use token as authentication provment:
+        curl \
+        -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX3BrIjoxLCJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiY29sZF9zdHVmZiI6IuKYgyIsImV4cCI6MTIzNDU2LCJqdGkiOiJmZDJmOWQ1ZTFhN2M0MmU4OTQ5MzVlMzYyYmNhOGJjYSJ9.NHlztMGER7UADHZJlxNG0WSi22a2KaYSfd1S-AuT7lU" \
+        http://localhost:8000/api/some-protected-view/
+
+    
+    Refresh token(when access token expired):
+        curl \
+        -X POST \
+        -H "Content-Type: application/json" \
+        -d '{"refresh":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX3BrIjoxLCJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImNvbGRfc3R1ZmYiOiLimIMiLCJleHAiOjIzNDU2NywianRpIjoiZGUxMmY0ZTY3MDY4NDI3ODg5ZjE1YWMyNzcwZGEwNTEifQ.aEoAYkSJjoWH1boshQAaTkf8G3yn0kapko6HFRt7Rh4"}' \
+        http://localhost:8000/api/token/refresh/
+
+        ...
+        {"access":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX3BrIjoxLCJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiY29sZF9zdHVmZiI6IuKYgyIsImV4cCI6MTIzNTY3LCJqdGkiOiJjNzE4ZTVkNjgzZWQ0NTQyYTU0NWJkM2VmMGI0ZGQ0ZSJ9.ekxRxgb9OKmHkfy-zs1Ro_xs1eMLXiR17dIDBVxeT-w"}
+
+For more docs: 
+    https://django-rest-framework-simplejwt.readthedocs.io/en/latest/

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ Django==3.1.6
 psycopg2==2.8.6
 python-dotenv==0.15.0
 djangorestframework==3.12.2
+djangorestframework-simplejwt==4.6.0

--- a/backend/socialdistribution/settings.py
+++ b/backend/socialdistribution/settings.py
@@ -157,3 +157,11 @@ STATIC_URL = '/static/'
 
 # add traling slash for api
 APPEND_SLASH = True
+
+# restframework
+REST_FRAMEWORK = {
+    # all views default to reqiure login to POST or DELETE
+    # can be overwrite in particular views
+    'DEFAULT_PERMISSION_CLASSES' : ('rest_framework.permissions.IsAuthenticatedOrReadOnly',),
+    # 'DEFAULT_AUTHENTICATION_CLASSES' : ('rest_framework_simplejwt.authentication.JWTAuthentication',)
+}

--- a/backend/socialdistribution/settings.py
+++ b/backend/socialdistribution/settings.py
@@ -163,5 +163,5 @@ REST_FRAMEWORK = {
     # all views default to reqiure login to POST or DELETE
     # can be overwrite in particular views
     'DEFAULT_PERMISSION_CLASSES' : ('rest_framework.permissions.IsAuthenticatedOrReadOnly',),
-    # 'DEFAULT_AUTHENTICATION_CLASSES' : ('rest_framework_simplejwt.authentication.JWTAuthentication',)
+    'DEFAULT_AUTHENTICATION_CLASSES' : ('rest_framework_simplejwt.authentication.JWTAuthentication',)
 }


### PR DESCRIPTION
## New: 
login, permission, JWT, displayName in author model, displayName and host in signup_request model
## Modify: 
fix user creation, delete token in author model
## 
**login and JWT:**
Username and password can't be used to login directly, the front end should send them to host_url/api/token to get JWT token.
Sending token within header to access api. An example is provided in 'auth_readme'.

**permission:**
All views default to require a login to POST or DELETE, which can be overwritten in particular views. 

**displayName field:**
Since if we use username as display name, when author changes it, it might be duplicated with signup_request's. 
So, to avoid that, use a separate field.

**host field:**
To store the host URL from request.get_host.

**token field:**
SimpleJWT can handle the token itself, we don't need it anymore.

**PS:**
A new requirement of simplejwt is added to backend.