### PR TITLE
Friend logic and follower api

### DIFF
--- a/backend/api/models/author.py
+++ b/backend/api/models/author.py
@@ -17,7 +17,7 @@ class Author(AbstractUser):
     host    = models.URLField(max_length=500)
     
     # Full URL referencing this user
-    url     = models.URLField()
+    url     = models.URLField(unique=True)
 
     # Github Connect
     github = models.URLField()

--- a/backend/api/models/follower.py
+++ b/backend/api/models/follower.py
@@ -1,11 +1,7 @@
 from django.db import models
 import uuid
-from django.core.exceptions import ValidationError
-from django.utils.translation import gettext_lazy as _
 # Related Model
 from api.models.author import Author
-
-
 
 class Follower(models.Model):
     # Unique ID of this follower Record
@@ -17,14 +13,10 @@ class Follower(models.Model):
     # The person who want to follow
     follower_url = models.URLField()
     # follower   = models.ForeignKey(Author, null=False, on_delete=models.CASCADE, related_name="follower")
-   
-  
-    # NOTE: Not exactly sure how connection to other servers will work but would we need to store author urls?
-    # Not sure yet so lets just hold off but might be needed, unless we can populate our author table with remote
-    # Authors, in which case this table is fine as-is.
 
     published  = models.DateTimeField(auto_now_add=True)
 
     class Meta:
-        unique_together = ['followee', 'follower_url',]
+        unique_together = ('followee', 'follower_url',)
+
 

--- a/backend/api/models/follower.py
+++ b/backend/api/models/follower.py
@@ -1,24 +1,30 @@
 from django.db import models
 import uuid
-
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
 # Related Model
 from api.models.author import Author
 
+
+
 class Follower(models.Model):
     # Unique ID of this follower Record
-    follow_id  = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False, unique=True)
+    record_id  = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False, unique=True)
     
-    # The person who want to follow
-    follower   = models.ForeignKey(Author, null=False, on_delete=models.CASCADE, related_name="follower")
-
     # The person who is being followed( The person who should get the request )
     followee   = models.ForeignKey(Author, null=False, on_delete=models.CASCADE, related_name="followee")
-    
-    url        = models.URLField()
 
+    # The person who want to follow
+    follower_url = models.URLField()
+    # follower   = models.ForeignKey(Author, null=False, on_delete=models.CASCADE, related_name="follower")
+   
+  
     # NOTE: Not exactly sure how connection to other servers will work but would we need to store author urls?
     # Not sure yet so lets just hold off but might be needed, unless we can populate our author table with remote
     # Authors, in which case this table is fine as-is.
 
     published  = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        unique_together = ['followee', 'follower_url',]
 

--- a/backend/api/models/follower.py
+++ b/backend/api/models/follower.py
@@ -18,9 +18,3 @@ class Follower(models.Model):
 
     class Meta:
         unique_together = ('followee', 'follower_url',)
-
-    def validate_unique(self,exclude=None):
-        try:
-            super(Parcare,self).validate_unique()
-        except ValidationError as e:
-            raise ValidationError(self.user+"your message")

--- a/backend/api/models/follower.py
+++ b/backend/api/models/follower.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.core.exceptions import NON_FIELD_ERRORS
 import uuid
 # Related Model
 from api.models.author import Author
@@ -12,11 +13,14 @@ class Follower(models.Model):
 
     # The person who want to follow
     follower_url = models.URLField()
-    # follower   = models.ForeignKey(Author, null=False, on_delete=models.CASCADE, related_name="follower")
-
+    
     published  = models.DateTimeField(auto_now_add=True)
 
     class Meta:
         unique_together = ('followee', 'follower_url',)
 
-
+    def validate_unique(self,exclude=None):
+        try:
+            super(Parcare,self).validate_unique()
+        except ValidationError as e:
+            raise ValidationError(self.user+"your message")

--- a/backend/api/models/friend.py
+++ b/backend/api/models/friend.py
@@ -15,8 +15,9 @@ class Friend(models.Model):
 
     # The friend of this author
     friend_url = models.URLField()
-    # my_friends_id = models.ForeignKey(Author, null=False, on_delete=models.CASCADE, related_name="my_friends_id")
-
+    
     published = models.DateTimeField(auto_now_add=True)
 
-    # Do we wanna know when someone was un-befriended? Or is it enough to simply delete a friend record?
+
+    class Meta:
+        unique_together = ('author', 'friend_url',)

--- a/backend/api/models/friend.py
+++ b/backend/api/models/friend.py
@@ -11,10 +11,10 @@ class Friend(models.Model):
     record_id  = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False, unique=True)
 
     # The author whose is primary in this relationship
-    author_id = models.ForeignKey(Author, null=False, on_delete=models.CASCADE, related_name="my_author_id")
+    author = models.ForeignKey(Author, null=False, on_delete=models.CASCADE, related_name="my_author_id")
 
     # The friend of this author
-    my_friends_url = models.URLField()
+    friend_url = models.URLField()
     # my_friends_id = models.ForeignKey(Author, null=False, on_delete=models.CASCADE, related_name="my_friends_id")
 
     published = models.DateTimeField(auto_now_add=True)

--- a/backend/api/models/friend.py
+++ b/backend/api/models/friend.py
@@ -7,14 +7,15 @@ from api.models.author import Author
 
 # NOTE: When a friend record is created there should be two records made, with each user as the primary friend
 class Friend(models.Model):
+    # Unique ID of this friend Record
+    record_id  = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False, unique=True)
+
     # The author whose is primary in this relationship
     author_id = models.ForeignKey(Author, null=False, on_delete=models.CASCADE, related_name="my_author_id")
 
     # The friend of this author
-    my_friends_id = models.ForeignKey(Author, null=False, on_delete=models.CASCADE, related_name="my_friends_id")
-
-    # Note Sure how this will work yet, please look into it when you work on friends
-    url= models.URLField(null=True)
+    my_friends_url = models.URLField()
+    # my_friends_id = models.ForeignKey(Author, null=False, on_delete=models.CASCADE, related_name="my_friends_id")
 
     published = models.DateTimeField(auto_now_add=True)
 

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -1,4 +1,4 @@
-from .models import author, post, signupRequest, comment, like
+from .models import author, post, signupRequest, comment, like, follower, friend
 from rest_framework import serializers
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 from django.core import serializers as serialize
@@ -67,3 +67,10 @@ class AuthorSerializer(serializers.ModelSerializer):
     instance.github = validated_data.get('github', instance.github)
     instance.save()
     return instance
+
+
+# serializer for follower model
+class FollowerSerializer(serializers.ModelSerializer):
+  class Meta:
+    model = follower.Follower
+    fields = ['followee', 'follower_url']

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -74,3 +74,9 @@ class FollowerSerializer(serializers.ModelSerializer):
   class Meta:
     model = follower.Follower
     fields = ['followee', 'follower_url']
+
+# serializer for friend model
+class FriendSerializer(serializers.ModelSerializer):
+  class Meta:
+    model = friend.Friend
+    fields = ['author', 'friend_url']

--- a/backend/api/services/followerServices.py
+++ b/backend/api/services/followerServices.py
@@ -1,0 +1,97 @@
+from ..models.follower import Follower
+from ..models.friend import Friend
+from ..serializers import FriendSerializer
+from rest_framework import status
+from rest_framework.response import Response
+from django.conf import settings
+import requests
+
+'''
+save a friend to db through serializer
+input:
+    str:id of author
+    str:url of friend
+return:
+    None
+'''
+def saveToFriend(id, url):
+    data = {}
+    data["author"] = id
+    data["friend_url"] = url
+    serializer = FriendSerializer(data=data)
+    if serializer.is_valid():
+        serializer.save()
+
+
+'''
+make friend if incoming follower complete a friend
+input:
+    str: id of followee
+    str: url of followee
+    str: url of follower
+return:
+    None
+'''
+def checkFriendMade(id_a, url_a, url_b):
+    # check if we are follower of b
+    split_list = url_b.split('author/')
+    host = split_list[0]
+    # if b host on our own, check follower in db
+    if host==settings.HEROKU_HOST:
+        id_b = split_list[1].split('/')[0]
+        try:
+            f = Follower.objects.get(followee__id__contains=id_b, follower_url=url_a)
+            # friend break, rm both side friend from db
+            # a            
+            saveToFriend(id_a, url_b)
+ 
+            # b
+            saveToFriend(id_b, url_a)
+
+        except:
+            pass
+
+    # else: get info from host
+    else:
+        if_follower_url = url_b + '/followers/' + str(id_a)
+        response = requests.get(if_follower_url).json()
+        # friend qualify, add b to a's friend
+        if response["detail"] == "true":
+            saveToFriend(id_a, url_b)
+
+'''
+rm friend if incoming follower breaks a friend
+input:
+    str: id of followee
+    str: url of followee
+    str: url of follower
+return:
+    None
+'''
+def checkFriendBreak(id_a, url_a, url_b):
+    # check if we are follower of b
+    split_list = url_b.split('author/')
+    host = split_list[0]
+
+    # if b host on our own, check follower in db
+    if host==settings.HEROKU_HOST:
+        id_b = split_list[1].split('/')[0]
+        try:
+            f = Follower.objects.get(followee__id__contains=id_b, follower_url=url_a)
+            # friend qualify, add both side friend to db
+            # a
+            Friend.objects.get(author__id__contains=id_a, friend_url=url_b).delete()
+ 
+            # b
+            Friend.objects.get(author__id__contains=id_b, friend_url=url_a).delete()
+
+        except:
+            pass
+
+    # else: get info from host
+    else:
+        if_follower_url = url_b + '/followers/' + str(id_a)
+        response = requests.get(if_follower_url).json()
+        # friend qualify, rm b from a's friend
+        if response["detail"] == "true":
+            Friend.objects.get(author__id__contains=id_a, friend_url=url_b).delete()

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path, re_path, include
 from django.conf.urls import url
 
-from .views import index, author, simplePostView, simpleSignupRequestView, authView, commentView, likeView
+from .views import index, author, simplePostView, simpleSignupRequestView, authView, commentView, likeView, followerView
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 # if you are adding a static path, consider put it on top of dynamic paths
@@ -20,6 +20,10 @@ urlpatterns = [
     
     # Profile Endpoint
     path('author/<str:id>/', author.author_profile_api, name="author-profile"),
+
+    # Follower Endpoint
+    path('author/<str:id>/followers/', followerView.get_followers_api, name="get-follower-of-author"),
+    path('author/<str:author_id>/followers/<str:foreign_author_id>', followerView.single_follower_manage_api, name="manage-single-follower"),
     
     # Token Endpoints
     path('api-auth/', include('rest_framework.urls')),    

--- a/backend/api/views/author.py
+++ b/backend/api/views/author.py
@@ -19,7 +19,7 @@ def author_profile_api(request, id):
     try:
         a = Author.objects.get(id=id)
     except:
-        return Response(status=404)
+        return Response({"detail": "author not found"}, status=404)
 
     if request.method == 'GET':
         serializer = AuthorSerializer(a)

--- a/backend/api/views/followerView.py
+++ b/backend/api/views/followerView.py
@@ -1,0 +1,113 @@
+from rest_framework import status
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+from django.conf import settings
+import requests
+
+from ..models.author import Author
+from ..serializers import AuthorSerializer, FollowerSerializer
+from ..models.follower import Follower
+
+from rest_framework.permissions import AllowAny
+from rest_framework.decorators import permission_classes
+
+'''
+Follower api for get a list of authors who are their followers
+# the followee must be hosted on our db #
+input:
+    str:author id
+return:
+    json or status code
+'''
+@api_view(['GET'])
+def get_followers_api(request, id):
+    # if author exist
+    try:
+        a = Author.objects.get(id=id)
+    except:
+        return Response(status=404)
+
+    f_list = Follower.objects.filter(followee__id__contains=id)
+    follower_item_list = []
+
+    # for friend of author, get info
+    for f in f_list:
+        split_list = f.follower_url.split('author/')
+        host = split_list[0]
+        
+        # if host on our own, get author info from db
+        if host==settings.HEROKU_HOST:
+            f_id = split_list[1].split('/')[0]
+            a = Author.objects.get(id=f_id)
+            serializer = AuthorSerializer(a)
+            follower_item_list.append(serializer.data)
+        # else: get info from host
+        else:
+            response = requests.get(f.follower_url)
+            follower_item_list.append(response.json())
+
+    # combine json
+    payload = {}
+    payload["type"] = "followers"
+    payload["items"] = follower_item_list
+
+    # print("follower",follower_item_list)
+    return Response(payload)
+
+'''
+manage a follower on our host:
+DELETE: remove a follower
+PUT: Add a follower (must be authenticated)
+GET: check if follower
+# the followee must be hosted on our db #
+
+input:
+    str:author id
+    str:follower id
+ouput:
+    json or status code
+'''
+@api_view(['GET', 'PUT', 'DELETE'])
+@permission_classes((AllowAny,)) # to rm############
+def single_follower_manage_api(request, author_id, foreign_author_id):
+    # if author exist
+    try:
+        a = Author.objects.get(id=author_id)
+    except:
+        return Response({"detail": "followee not found"}, status=404)
+
+    # make follower url    
+    host = request.get_host()
+    if request.is_secure():
+        protocol = 'https://'
+    else:
+        protocol = 'http://'
+    host = protocol + host + '/'
+    f_url = host + 'author/' + foreign_author_id
+
+    # GET check if follower
+    if request.method == 'GET':
+        try:
+            f = Follower.objects.get(followee__id__contains=author_id, follower_url=f_url)
+            return Response({"detail": "true"})
+        except:
+            return Response({"detail": "false"})
+
+    # PUT: Add a follower (must be authenticated)
+    elif request.method == 'PUT':
+        data = {}
+        data["followee"] = a.id
+        data["follower_url"] = f_url
+        serializer = FollowerSerializer(data=data)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data)
+        return Response(serializer.errors, status=400)
+
+    # DELETE: remove a follower
+    elif request.method == 'DELETE':
+        try:
+            f = Follower.objects.get(followee__id__contains=author_id, follower_url=f_url).delete()
+            return Response(status=200)
+        except:
+            return Response({"detail": "follower not found"}, status=404)

--- a/backend/socialdistribution/settings.py
+++ b/backend/socialdistribution/settings.py
@@ -40,8 +40,8 @@ EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 PROD = int(os.environ.get('PROD', default=1))
-
-ALLOWED_HOSTS = [os.environ.get('HEROKU_HOST'), '0.0.0.0', 'localhost', '127.0.0.1']
+HEROKU_HOST = os.environ.get('HEROKU_HOST')
+ALLOWED_HOSTS = [HEROKU_HOST, '0.0.0.0', 'localhost', '127.0.0.1']
 
 
 # Application definition

--- a/frontend/src/components/auth/RegisterForm.jsx
+++ b/frontend/src/components/auth/RegisterForm.jsx
@@ -18,7 +18,7 @@ import {clearErrors} from '../../actions/errorActions';
 
 class RegisterForm extends React.Component {
     state = {
-        msgs: [],
+        msgs: [["Successfully Registered! ", "Please await admin approval before Login!"]],
         msg_type: null ,   
     };
 
@@ -95,6 +95,7 @@ class RegisterForm extends React.Component {
           <Form.Item
             name="github"
             rules={[{ required: true, message: 'Please input your Github URL!' }]}
+            initialValue='https://github.com/'
           >
             <Input prefix={<GithubOutlined />} placeholder="Github URL" />
           </Form.Item>


### PR DESCRIPTION
Friend logic and follower api
github register has initial url, become "frontend optional"

remote befriend and unfriend is implemented, but only tested locally.

To befriend, both authors follow each other through PUT to API.
To un friend, one or both of authors unfollow through DELETE API.